### PR TITLE
Clean submodules before fetching

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -3,38 +3,38 @@ description: Merge code back into develop on push to main
 
 inputs:
   src-branch:
-    description: "What branch is acting as the source of the merger"
+    description: 'What branch is acting as the source of the merger'
     required: false
-    default: "main"
+    default: 'main'
   dest-branch:
-    description: "What branch is acting as the destination of the merger"
+    description: 'What branch is acting as the destination of the merger'
     required: false
     default: ${{ github.event.repository.default_branch }}
   submodules:
-    description: "Whether to checkout submodules"
+    description: 'Whether to checkout submodules'
     required: false
-    default: "false"
+    default: 'false'
   token:
-    description: "The token to access private repos"
+    description: 'The token to access private repos'
     required: false
   commit-message:
-    description: "The commit message to use for the merge"
+    description: 'The commit message to use for the merge'
     required: false
   commit-author-name:
-    description: "The author name to use for the merge"
+    description: 'The author name to use for the merge'
     required: false
-    default: "github-actions"
+    default: 'github-actions'
   commit-author-email:
-    description: "The email to use for the merge"
+    description: 'The email to use for the merge'
     required: false
-    default: "github-actions@github.com"
-  commit-flags:
-    description: "The git merge flags to use for the merge"
+    default: 'github-actions@github.com'
+  commit-flags: 
+    description: 'The git merge flags to use for the merge'
     required: false
-    default: "--no-verify --strategy-option theirs --allow-unrelated-histories"
+    default: '--no-verify --strategy-option theirs --allow-unrelated-histories'
 
 runs:
-  using: "composite"
+  using: 'composite'
   steps:
     - uses: actions/checkout@v3
       with:

--- a/action.yaml
+++ b/action.yaml
@@ -3,38 +3,38 @@ description: Merge code back into develop on push to main
 
 inputs:
   src-branch:
-    description: 'What branch is acting as the source of the merger'
+    description: "What branch is acting as the source of the merger"
     required: false
-    default: 'main'
+    default: "main"
   dest-branch:
-    description: 'What branch is acting as the destination of the merger'
+    description: "What branch is acting as the destination of the merger"
     required: false
     default: ${{ github.event.repository.default_branch }}
   submodules:
-    description: 'Whether to checkout submodules'
+    description: "Whether to checkout submodules"
     required: false
-    default: 'false'
+    default: "false"
   token:
-    description: 'The token to access private repos'
+    description: "The token to access private repos"
     required: false
   commit-message:
-    description: 'The commit message to use for the merge'
+    description: "The commit message to use for the merge"
     required: false
   commit-author-name:
-    description: 'The author name to use for the merge'
+    description: "The author name to use for the merge"
     required: false
-    default: 'github-actions'
+    default: "github-actions"
   commit-author-email:
-    description: 'The email to use for the merge'
+    description: "The email to use for the merge"
     required: false
-    default: 'github-actions@github.com'
-  commit-flags: 
-    description: 'The git merge flags to use for the merge'
+    default: "github-actions@github.com"
+  commit-flags:
+    description: "The git merge flags to use for the merge"
     required: false
-    default: '--no-verify --strategy-option theirs --allow-unrelated-histories'
+    default: "--no-verify --strategy-option theirs --allow-unrelated-histories"
 
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
     - uses: actions/checkout@v3
       with:
@@ -59,6 +59,12 @@ runs:
         else
           echo "message=Merge branch '${{ steps.src-branch.outputs.branch }}' into '${{ inputs.dest-branch }}'" >> $GITHUB_OUTPUT
         fi
+      shell: bash
+    - name: Clean submodules
+      if: inputs.submodules == 'true'
+      run: |
+        git submodule foreach --recursive 'git reset --hard'
+        git submodule foreach --recursive 'git clean -fdx'
       shell: bash
     - name: Merge
       run: |


### PR DESCRIPTION
### What problem are you trying to solve with this PR?

Mobile is experiencing an error during back merge. 
Specifically git fetch is pulling outdated refs and trying to fetch them

This results in the error
`fatal: remote error: upload-pack: not our ref HASH`

Cleaning the submodules prior to fetching fixes this issue.

### How did you decide to solve the problem?

<!-- Did you consider any alternative solutions and why did you decide against them? -->

### Are you adding any new dependencies in this PR?

### Is there anything in this pull request that you would like reviewers to look at closely?

### Will this change affect any other teams?

<!-- Add any teams who will need to be made aware of these changes to the PR. -->

### Do you have any gripes you want to get off your chest?
