### PR TITLE
Fix diverged branches error when checking out the already checked out branch

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -65,8 +65,11 @@ runs:
         git config user.email ${{ inputs.commit-author-email }}
         git config user.name ${{ inputs.commit-author-name }}
         git fetch --depth=1
-        # Ensure the branch exists locally
-        git switch ${{ steps.src-branch.outputs.branch }}
+        # Do not switch if branch already is checked out
+        if [ $(git branch --show-current) != ${{ steps.src-branch.outputs.branch }} ]; then
+          # Ensure the branch exists locally
+          git switch ${{ steps.src-branch.outputs.branch }}
+        fi
         git pull
         git switch ${{ inputs.dest-branch }}
         git pull


### PR DESCRIPTION
### What problem are you trying to solve with this PR?

The following error is occurring when gha-back-merge is called after a previous step in the GHA triggers a new commit to the same [branch]. 
This occurs in the mobile release process for every release action flow due to the incrementation of the build number for iOS.

```
Already on '[branch]'
Your branch and 'origin/[branch]' have diverged,
and have 1 and 1 different commits each, respectively.
  (use "git pull" to merge the remote branch into yours)
```

### How did you decide to solve the problem?

Skip switching branches when already on the desired branch.

### Are you adding any new dependencies in this PR?

### Is there anything in this pull request that you would like reviewers to look at closely?

### Will this change affect any other teams?

<!-- Add any teams who will need to be made aware of these changes to the PR. -->

### Do you have any gripes you want to get off your chest?
